### PR TITLE
fix(team): enable null team

### DIFF
--- a/client/business/BlindTest.ts
+++ b/client/business/BlindTest.ts
@@ -27,7 +27,7 @@ interface IBlindTestResultDetails {
 export function computeDetails(context: IContext) {
   const emptyTeamHashMap = context.teams.reduce<IBlindTestResultDetails>(
     (acc, team) => ({ ...acc, [team]: [] }),
-    {}
+    { null: [] }
   );
 
   return context.results.reduce(
@@ -47,7 +47,7 @@ export function computeWinner(
 ): { team: ITeam | null; score: number } {
   return Object.entries(details).reduce<{ team: ITeam | null; score: number }>(
     (acc, [team, songs]) =>
-      songs.length > acc.score ? { team, score: songs.length } : acc,
+      team && songs.length > acc.score ? { team, score: songs.length } : acc,
     { team: null, score: 0 }
   );
 }


### PR DESCRIPTION
ugly fix to prevent crash on score screen when some songs were won by no one;
it instead apears as "won by null" for the record